### PR TITLE
discovered bug for compareLists in Tester.java for LLStacksQueues HW

### DIFF
--- a/homeworks/LLStacksQueues/code/LLStacksQueues/src/tester/Tester.java
+++ b/homeworks/LLStacksQueues/code/LLStacksQueues/src/tester/Tester.java
@@ -25,6 +25,7 @@ public class Tester {
 			if(!it1.next().equals(it2.value())) return false;
 			it2.moveForward();
 		}
+		if(it2.isPastEnd() && it1.hasNext()) return false;
 		
 		//check backwards
 		it1 = list1.descendingIterator();
@@ -33,6 +34,8 @@ public class Tester {
 			if(!it1.next().equals(it2.value())) return false;
 			it2.moveBackward();
 		}
+		if(it2.isPastBeginning() && it1.hasNext()) return false;
+
 		return true;
 	}
 	


### PR DESCRIPTION
I took 2100 last semester, but I was helping someone debug their code and found this bug. compareLists will return true even if the two lists are not the same when the student-implemented linkedlist's size variable is not representative of the actual list size.